### PR TITLE
Remove `private` from Emojis.all

### DIFF
--- a/buildSrc/src/main/kotlin/dev/kord/x/emoji/Generator.kt
+++ b/buildSrc/src/main/kotlin/dev/kord/x/emoji/Generator.kt
@@ -127,7 +127,6 @@ class EmojiPlugin : Plugin<Project> {
             }
             }    
                     |)""".trimMargin())
-            addModifiers(KModifier.PRIVATE)
         }
 
         addProperty(property)

--- a/src/main/kotlin/dev/kord/x/emoji/EmojiList.kt
+++ b/src/main/kotlin/dev/kord/x/emoji/EmojiList.kt
@@ -14,7 +14,7 @@ import kotlin.collections.Map
   "unused",
 )
 public object Emojis {
-  private val all: Map<String, DiscordEmoji> = mapOf(
+  val all: Map<String, DiscordEmoji> = mapOf(
               "\uD83D\uDE00" to `grinning`,
               "\uD83D\uDE03" to `smiley`,
               "\uD83D\uDE04" to `smile`,

--- a/src/main/kotlin/dev/kord/x/emoji/EmojiList.kt
+++ b/src/main/kotlin/dev/kord/x/emoji/EmojiList.kt
@@ -14,7 +14,7 @@ import kotlin.collections.Map
   "unused",
 )
 public object Emojis {
-  val all: Map<String, DiscordEmoji> = mapOf(
+  public val all: Map<String, DiscordEmoji> = mapOf(
               "\uD83D\uDE00" to `grinning`,
               "\uD83D\uDE03" to `smiley`,
               "\uD83D\uDE04" to `smile`,


### PR DESCRIPTION
This seems unnecessarily restrictive. A full list of all emoji available in discord can be useful in many circumstances.

My own use-case for this would be to find emoji in messages (for which helper methods could be added if desired). The latest unicode standard does allow for doing this with `\p{Emoji}` I think, but that doesn't work in the latest version of the JVM and could conceivably match with emoji not supported by discord. Matching for ranges is also not great since it's quite difficult to find where emojis begin and end if there aren't any spaces between them.